### PR TITLE
support for exclusions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,14 @@ go build
 
 Scan some package registries!
 ```
-./typo-scanner npm react -dr
+./typo-scanner npm -dr react
 ```
 The `-dr` specified above will search for [d]uplicate and [r]eversed character typos.
+
+If a legitimate package is getting flagged incorrectly, use the [e]xclude flag to ignore it in your results.
+```
+./typo-scanner pypi fastapi -d -x faastapi
+```
 
 For more details on flags and command options explore the detailed help commands.
 ```

--- a/cmd/godev.go
+++ b/cmd/godev.go
@@ -5,7 +5,6 @@ package cmd
 
 import (
 	"github.com/dsm0014/typo-scanner/scanner"
-	"github.com/dsm0014/typo-scanner/typo"
 	"github.com/spf13/cobra"
 )
 
@@ -20,8 +19,7 @@ Example:
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		for _, pkg := range args {
-			typoList := typo.TypoGenerator(pkg, genFlags)
-			_, err := scanner.ScanGo(pkg, typoList)
+			_, err := scanner.ScanGo(pkg, genFlags)
 			if err != nil {
 				return err
 			}

--- a/cmd/godev.go
+++ b/cmd/godev.go
@@ -4,9 +4,9 @@ Copyright © 2022 Daniel Morrison
 package cmd
 
 import (
-	"github.com/spf13/cobra"
 	"github.com/dsm0014/typo-scanner/scanner"
 	"github.com/dsm0014/typo-scanner/typo"
+	"github.com/spf13/cobra"
 )
 
 var godevCmd = &cobra.Command{
@@ -20,7 +20,7 @@ Example:
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		for _, pkg := range args {
-			typoList := typo.TypoGenerator(pkg, typoFlags)
+			typoList := typo.TypoGenerator(pkg, genFlags)
 			_, err := scanner.ScanGo(pkg, typoList)
 			if err != nil {
 				return err

--- a/cmd/mvn.go
+++ b/cmd/mvn.go
@@ -4,9 +4,9 @@ Copyright © 2022 Daniel Morrison
 package cmd
 
 import (
-	"github.com/spf13/cobra"
 	"github.com/dsm0014/typo-scanner/scanner"
 	"github.com/dsm0014/typo-scanner/typo"
+	"github.com/spf13/cobra"
 )
 
 var mvnCmd = &cobra.Command{
@@ -20,7 +20,7 @@ Example:
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		for _, pkg := range args {
-			typoList := typo.TypoGenerator(pkg, typoFlags)
+			typoList := typo.TypoGenerator(pkg, genFlags)
 			_, err := scanner.ScanMvn(pkg, typoList)
 			if err != nil {
 				return err

--- a/cmd/mvn.go
+++ b/cmd/mvn.go
@@ -5,7 +5,6 @@ package cmd
 
 import (
 	"github.com/dsm0014/typo-scanner/scanner"
-	"github.com/dsm0014/typo-scanner/typo"
 	"github.com/spf13/cobra"
 )
 
@@ -20,8 +19,7 @@ Example:
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		for _, pkg := range args {
-			typoList := typo.TypoGenerator(pkg, genFlags)
-			_, err := scanner.ScanMvn(pkg, typoList)
+			_, err := scanner.ScanMvn(pkg, genFlags)
 			if err != nil {
 				return err
 			}

--- a/cmd/npm.go
+++ b/cmd/npm.go
@@ -4,9 +4,9 @@ Copyright © 2022 Daniel Morrison
 package cmd
 
 import (
-	"github.com/spf13/cobra"
 	"github.com/dsm0014/typo-scanner/scanner"
 	"github.com/dsm0014/typo-scanner/typo"
+	"github.com/spf13/cobra"
 )
 
 var npmCmd = &cobra.Command{
@@ -19,7 +19,7 @@ Example:
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		for _, pkg := range args {
-			typoList := typo.TypoGenerator(pkg, typoFlags)
+			typoList := typo.TypoGenerator(pkg, genFlags)
 			_, err := scanner.ScanNpm(pkg, typoList)
 			if err != nil {
 				return err

--- a/cmd/npm.go
+++ b/cmd/npm.go
@@ -5,7 +5,6 @@ package cmd
 
 import (
 	"github.com/dsm0014/typo-scanner/scanner"
-	"github.com/dsm0014/typo-scanner/typo"
 	"github.com/spf13/cobra"
 )
 
@@ -19,8 +18,7 @@ Example:
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		for _, pkg := range args {
-			typoList := typo.TypoGenerator(pkg, genFlags)
-			_, err := scanner.ScanNpm(pkg, typoList)
+			_, err := scanner.ScanNpm(pkg, genFlags)
 			if err != nil {
 				return err
 			}

--- a/cmd/pypi.go
+++ b/cmd/pypi.go
@@ -4,9 +4,9 @@ Copyright © 2022 Daniel Morrison
 package cmd
 
 import (
-	"github.com/spf13/cobra"
 	"github.com/dsm0014/typo-scanner/scanner"
 	"github.com/dsm0014/typo-scanner/typo"
+	"github.com/spf13/cobra"
 )
 
 var pypiCmd = &cobra.Command{
@@ -19,7 +19,7 @@ Example:
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		for _, pkg := range args {
-			typoList := typo.TypoGenerator(pkg, typoFlags)
+			typoList := typo.TypoGenerator(pkg, genFlags)
 			_, err := scanner.ScanPypi(pkg, typoList)
 			if err != nil {
 				return err

--- a/cmd/pypi.go
+++ b/cmd/pypi.go
@@ -5,7 +5,6 @@ package cmd
 
 import (
 	"github.com/dsm0014/typo-scanner/scanner"
-	"github.com/dsm0014/typo-scanner/typo"
 	"github.com/spf13/cobra"
 )
 
@@ -19,8 +18,7 @@ Example:
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		for _, pkg := range args {
-			typoList := typo.TypoGenerator(pkg, genFlags)
-			_, err := scanner.ScanPypi(pkg, typoList)
+			_, err := scanner.ScanPypi(pkg, genFlags)
 			if err != nil {
 				return err
 			}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,8 +13,8 @@ import (
 )
 
 var (
-	cfgFile   string
-	typoFlags typo.TypoFlags
+	cfgFile  string
+	genFlags typo.GeneratorFlags
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -27,6 +27,10 @@ attempting to impersonate your package and wreak havoc via TypoSquatting.
 The typo-scanner CLI is a lightweight tool for discovering if your packages
 are being subject to this form of Software Supply Chain attack. The scanner 
 generates a multitude of types of typos and verifies whether they exist or not.
+
+Examples:
+  typo-scanner npm -dr react
+  typo-scanner pypi -d fastapi -x faastapi
 `,
 }
 
@@ -48,12 +52,13 @@ func init() {
 
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.typo-scanner.yaml)")
 
-	rootCmd.PersistentFlags().BoolVarP(&typoFlags.ExtraKey, "extra-key", "e", false, "Check for typos with an additional character")
-	rootCmd.PersistentFlags().BoolVarP(&typoFlags.Skip, "skip", "s", false, "Check for typos with skipped characters")
-	rootCmd.PersistentFlags().BoolVarP(&typoFlags.Double, "double", "d", false, "Check for typos with doubled characters")
-	rootCmd.PersistentFlags().BoolVarP(&typoFlags.Reverse, "reverse", "r", false, "Check for typos with reversed characters")
-	rootCmd.PersistentFlags().BoolVarP(&typoFlags.Vowel, "vowel", "v", false, "Check for typos with incorrect vowels")
-	rootCmd.PersistentFlags().BoolVarP(&typoFlags.Key, "key", "k", false, "Check for typos with any incorrect characters")
+	rootCmd.PersistentFlags().BoolVarP(&genFlags.Typo.ExtraKey, "extra-key", "e", false, "Check for typos with an additional character")
+	rootCmd.PersistentFlags().BoolVarP(&genFlags.Typo.Skip, "skip", "s", false, "Check for typos with skipped characters")
+	rootCmd.PersistentFlags().BoolVarP(&genFlags.Typo.Double, "double", "d", false, "Check for typos with doubled characters")
+	rootCmd.PersistentFlags().BoolVarP(&genFlags.Typo.Reverse, "reverse", "r", false, "Check for typos with reversed characters")
+	rootCmd.PersistentFlags().BoolVarP(&genFlags.Typo.Vowel, "vowel", "v", false, "Check for typos with incorrect vowels")
+	rootCmd.PersistentFlags().BoolVarP(&genFlags.Typo.Key, "key", "k", false, "Check for typos with any incorrect characters")
+	rootCmd.PersistentFlags().StringSliceVarP(&genFlags.Excluded, "excluded", "x", []string{}, "Array of typos to exclude from scans (ex: -x faastapi,fasttapi)")
 
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.

--- a/cmd/ruby.go
+++ b/cmd/ruby.go
@@ -5,7 +5,6 @@ package cmd
 
 import (
 	"github.com/dsm0014/typo-scanner/scanner"
-	"github.com/dsm0014/typo-scanner/typo"
 	"github.com/spf13/cobra"
 )
 
@@ -19,8 +18,7 @@ Example:
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		for _, pkg := range args {
-			typoList := typo.TypoGenerator(pkg, genFlags)
-			_, err := scanner.ScanRuby(pkg, typoList)
+			_, err := scanner.ScanRuby(pkg, genFlags)
 			if err != nil {
 				return err
 			}

--- a/cmd/ruby.go
+++ b/cmd/ruby.go
@@ -4,9 +4,9 @@ Copyright © 2022 Daniel Morrison
 package cmd
 
 import (
-	"github.com/spf13/cobra"
 	"github.com/dsm0014/typo-scanner/scanner"
 	"github.com/dsm0014/typo-scanner/typo"
+	"github.com/spf13/cobra"
 )
 
 var rubyCmd = &cobra.Command{
@@ -19,7 +19,7 @@ Example:
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		for _, pkg := range args {
-			typoList := typo.TypoGenerator(pkg, typoFlags)
+			typoList := typo.TypoGenerator(pkg, genFlags)
 			_, err := scanner.ScanRuby(pkg, typoList)
 			if err != nil {
 				return err

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -2,75 +2,45 @@ package scanner
 
 import (
 	"fmt"
+	"github.com/dsm0014/typo-scanner/typo"
 	"io"
 	"log"
 	"net/http"
 	"strings"
+	"sync"
 )
 
-func ScanGo(original string, typos []string) ([]string, error) {
-	return Scan(Godev, GodevUrl, original, typos)
+func ScanGo(original string, flags typo.GeneratorFlags) ([]string, error) {
+	return Scan(Godev, GodevUrl, original, flags)
 }
 
-func ScanMvn(original string, typos []string) ([]string, error) {
-	return Scan(Mvn, MvnUrl, original, typos)
+func ScanMvn(original string, flags typo.GeneratorFlags) ([]string, error) {
+	return Scan(Mvn, MvnUrl, original, flags)
 }
 
-func ScanNpm(original string, typos []string) ([]string, error) {
-	return Scan(Npm, NpmUrl, original, typos)
+func ScanNpm(original string, flags typo.GeneratorFlags) ([]string, error) {
+	return Scan(Npm, NpmUrl, original, flags)
 }
 
-func ScanPypi(original string, typos []string) ([]string, error) {
-	return Scan(Pypi, PypiUrl, original, typos)
+func ScanPypi(original string, flags typo.GeneratorFlags) ([]string, error) {
+	return Scan(Pypi, PypiUrl, original, flags)
 }
 
-func ScanRuby(original string, typos []string) ([]string, error) {
-	return Scan(Ruby, RubyUrl, original, typos)
+func ScanRuby(original string, flags typo.GeneratorFlags) ([]string, error) {
+	return Scan(Ruby, RubyUrl, original, flags)
 }
 
-func Scan(pkgType PkgType, pkgUrl PkgUrl, original string, typos []string) ([]string, error) {
+func Scan(pkgType PkgType, pkgUrl PkgUrl, original string, flags typo.GeneratorFlags) ([]string, error) {
 	log.Printf("Scanning %s for typos of: %s", pkgType, original)
 	var matches []string
-	for _, typo := range typos {
-		resp, err := http.Get(fmt.Sprintf("%s%s", pkgUrl, typo))
-		if err != nil {
-			log.Printf("Error looking up NPM package: %s", err)
-		}
-		defer resp.Body.Close()
-		
-		// Early exit if the page 404's
-		if resp.StatusCode == http.StatusNotFound {
-			log.Printf("No results in %s for: %s", pkgType, typo)
-			continue
-		}
-		
-		bodyBytes, err := io.ReadAll(resp.Body)
-		if err != nil {
-			log.Fatal(err)
-			return nil, err
-		}
-		bodyString := string(bodyBytes)
-
-		// Additional checks which may indicate/disprove TypoSquatting
-		switch pkgType {
-		case Npm:
-			// Sometimes packages that were previously tagged as malicious will have the URL lying around but not be active
-			if strings.Contains(bodyString, "You may adopt this package by contacting") {
-				log.Printf("Previous TypoSquatter found in %s using the name: %s\n", pkgType, typo)
-				continue
-			}
-		case Mvn:
-			// Maven is weird
-			if resp.StatusCode == http.StatusForbidden {
-				log.Printf("No results in %s for: %s", pkgType, typo)
-				continue
-			}
-		default:
-		}
-
-		log.Printf("Active TypoSquatter found in %s using the name: %s\n", pkgType, typo)
-		matches = append(matches, typo)
+	typos := typo.TypoGenerator(original, flags)
+	var wg sync.WaitGroup
+	wg.Add(len(typos))
+	for _, t := range typos {
+		go ScanTypoRoutine(&wg, pkgType, pkgUrl, &matches, t)
 	}
+	wg.Wait()
+	log.Printf("%d typos scanned in %s", len(typos), pkgType)
 	if len(matches) > 0 {
 		log.Printf("%d matches found in %s", len(matches), pkgType)
 		log.Fatal(fmt.Sprintf("Potential TypoSquatters: %s", matches))
@@ -78,4 +48,45 @@ func Scan(pkgType PkgType, pkgUrl PkgUrl, original string, typos []string) ([]st
 	}
 	log.Printf("SUCCESS: %d TypoSquatters found in %s!", len(matches), pkgType)
 	return matches, nil
+}
+
+func ScanTypoRoutine(wg *sync.WaitGroup, pkgType PkgType, pkgUrl PkgUrl, matches *[]string, t string) {
+	defer wg.Done()
+	resp, err := http.Get(fmt.Sprintf("%s%s", pkgUrl, t))
+	if err != nil {
+		log.Fatalf("Error looking up NPM package: %s", err)
+	}
+	defer resp.Body.Close()
+
+	// Early exit if the page 404's
+	if resp.StatusCode == http.StatusNotFound {
+		log.Printf("No results in %s for: %s", pkgType, t)
+		return
+	}
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatal(err)
+	}
+	bodyString := string(bodyBytes)
+
+	// Additional checks which may indicate/disprove TypoSquatting
+	switch pkgType {
+	case Npm:
+		// Sometimes packages that were previously tagged as malicious will have the URL lying around but not be active
+		if strings.Contains(bodyString, "You may adopt this package by contacting") {
+			log.Printf("Previous TypoSquatter found in %s using the name: %s\n", pkgType, t)
+			return
+		}
+	case Mvn:
+		// Maven is weird
+		if resp.StatusCode == http.StatusForbidden {
+			log.Printf("No results in %s for: %s", pkgType, t)
+			return
+		}
+	default:
+	}
+
+	log.Printf("Active TypoSquatter found in %s using the name: %s\n", pkgType, t)
+	*matches = append(*matches, t)
 }

--- a/typo/flags.go
+++ b/typo/flags.go
@@ -19,3 +19,8 @@ func NewTypoFlags() TypoFlags {
 		Key:      false,
 	}
 }
+
+type GeneratorFlags struct {
+	Excluded []string
+	Typo     TypoFlags
+}

--- a/typo/generator.go
+++ b/typo/generator.go
@@ -4,27 +4,27 @@ import (
 	"log"
 )
 
-func TypoGenerator(baseline string, flags TypoFlags) []string {
-	if flags == NewTypoFlags() {
+func TypoGenerator(baseline string, genFlags GeneratorFlags) []string {
+	if genFlags.Typo == NewTypoFlags() {
 		log.Fatal("ERROR: At least one typo flag must be specified")
 	}
-	t := NewTypos(baseline)
-	if flags.ExtraKey {
+	t := NewTypos(baseline, genFlags.Excluded)
+	if genFlags.Typo.ExtraKey {
 		t.InsertedKey()
 	}
-	if flags.Skip {
+	if genFlags.Typo.Skip {
 		t.SkipLetter()
 	}
-	if flags.Double {
+	if genFlags.Typo.Double {
 		t.DoubleLetter()
 	}
-	if flags.Reverse {
+	if genFlags.Typo.Reverse {
 		t.ReverseLetter()
 	}
-	if flags.Vowel {
+	if genFlags.Typo.Vowel {
 		t.WrongVowel()
 	}
-	if flags.Key {
+	if genFlags.Typo.Key {
 		t.WrongKey()
 	}
 	return t.Typos

--- a/typo/typos.go
+++ b/typo/typos.go
@@ -10,19 +10,27 @@ const (
 )
 
 type typos struct {
+	Excluded []string
 	Original string
 	Typos    []string
 }
 
-func NewTypos(original string) *typos {
+func NewTypos(original string, excluded []string) *typos {
 	return &typos{
 		Original: original,
+		Excluded: excluded,
 	}
 }
 
 func (t *typos) AddTypo(s string) {
 	if s == t.Original {
 		return
+	}
+
+	for _, b := range t.Excluded {
+		if s == b {
+			return
+		}
 	}
 
 	for _, b := range t.Typos {

--- a/typo/typos_test.go
+++ b/typo/typos_test.go
@@ -7,6 +7,7 @@ import (
 type fields struct {
 	Original string
 	Typos    []string
+	Excluded []string
 }
 
 type typotest struct {
@@ -27,6 +28,7 @@ func Test_typos_AddTypo(t1 *testing.T) {
 	}{
 		{"DontAddSameAsOriginal", fields{Original: "ddog"}, args{s: "ddog"}, 0},
 		{"DontAddExisting", fields{Original: "cat", Typos: []string{"ccat"}}, args{s: "ccat"}, 1},
+		{"DontAddExcluded", fields{Original: "fastapi", Typos: []string{"ffastapi"}, Excluded: []string{"faastapi"}}, args{s: "faastapi"}, 1},
 		{"DoAddNew", fields{Original: "dog"}, args{s: "ddog"}, 1},
 	}
 	for _, tt := range tests {
@@ -34,6 +36,7 @@ func Test_typos_AddTypo(t1 *testing.T) {
 			t := &typos{
 				Original: tt.fields.Original,
 				Typos:    tt.fields.Typos,
+				Excluded: tt.fields.Excluded,
 			}
 			t.AddTypo(tt.args.s)
 			if tt.resultLength != len(t.Typos) {


### PR DESCRIPTION
Adds support for excluding known, legitimate packages from scans with the `--exclude <item1>,<item2>` (shorthand `-x`) global flag.

Parallelizes scans using GoRoutines, speeding up large (20+ typo) scans by a massive amount